### PR TITLE
Produce typeface.json instead

### DIFF
--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -101,7 +101,7 @@ var convert = function(font){
     } else {
         result.cssFontStyle = "normal";
     };
-    return "if (_typeface_js && _typeface_js.loadFace) _typeface_js.loadFace("+ JSON.stringify(result) + ");"
+    return JSON.stringify(result);
 };
 
 var reverseCommands = function(commands){


### PR DESCRIPTION
I have "converted" the *typeface.js files to *typeface.json in three.js by simply removing the `if (_typeface_js && _typeface_js.loadFace) _typeface_js.loadFace(` header.

https://github.com/mrdoob/three.js/commit/629e59ff6ce3c6029fef2abc3b9983a91175b91d

This allow us to load font files in a more javascripty way (I'm still refactoring the code), and we can remove the `_typeface_js` hacks.

https://github.com/mrdoob/three.js/commit/38dd0a599411d0d75f48ba1011314f5a6c0b79cd

I would suggest renaming this repository to `typeface.json` 😊
