### PR TITLE
Adding a checkbox for js vs json file type export

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,11 +34,27 @@
             <input id="fileInput" type="file" multiple/>
           </div>
           <div class="inputRow">
-              <input id="reverseTypeface" type="checkbox"/>
-              <label for="reverseTypeface">
-                Reverse font direction.
-                <p class="deemphasized">Use this to fix issues with holes in characters like 'd', 'o' and '8'.</p>
+            <div class="col">
+              <input id="filetypeJson" type="radio" name="filetype" value="json" checked/>
+              <label for="filetypeJson">
+                Generate a JSON file (.json)
+                <p class="deemphasized">This will export only the font data and not include the facetype.js declaration script.</p>
               </label>
+            </div>
+            <div class="col">
+              <input id="filetypeJs" type="radio" name="filetype" value="js"/>
+              <label for="filetypeJs">
+                Generate a JavasScript file (.js)
+                <p class="deemphasized">This will export a JavaScript file that includes the facetype.js script execution. This is for legacy compatibility with older projects.</p>
+              </label>
+            </div>
+          </div>
+          <div class="inputRow">
+            <input id="reverseTypeface" type="checkbox"/>
+            <label for="reverseTypeface">
+              Reverse font direction.
+              <p class="deemphasized">Use this to fix issues with holes in characters like 'd', 'o' and '8'.</p>
+            </label>
           </div>
           <div>
           <input id="convert" type="submit" title= "convert" value="Convert" />

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -1,6 +1,7 @@
 var convert = document.getElementById("convert");
 var fileInput = document.getElementById("fileInput");
 var reverseTypeface = document.getElementById("reverseTypeface");
+var filetypeJson = document.getElementById("filetypeJson");
 convert.onclick = function(){
 
     [].forEach.call(fileInput.files,function(file){
@@ -8,7 +9,7 @@ convert.onclick = function(){
         reader.addEventListener( 'load', function ( event ) {
             var font = opentype.parse(event.target.result);
             var result = convert(font);
-            exportString(result,font.familyName + "_" + font.styleName  + ".js");
+            exportString(result,font.familyName + "_" + font.styleName + ( filetypeJson.checked ? ".json" : ".js" ) );
         }, false );
         reader.readAsArrayBuffer( file );
     });
@@ -101,7 +102,12 @@ var convert = function(font){
     } else {
         result.cssFontStyle = "normal";
     };
-    return "if (_typeface_js && _typeface_js.loadFace) _typeface_js.loadFace("+ JSON.stringify(result) + ");"
+
+    if(filetypeJson.checked) {
+        return JSON.stringify(result);
+    } else {
+        return "if (_typeface_js && _typeface_js.loadFace) _typeface_js.loadFace("+ JSON.stringify(result) + ");"
+    }
 };
 
 var reverseCommands = function(commands){

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -257,7 +257,7 @@ form {
 }
 
 .inputRow {
-  margin: 10px 0;
+  margin: 15px 0;
 }
 
 .deemphasized {
@@ -378,7 +378,10 @@ Full-Width Styles
   background: #212121;
 }
 
-
+.col {
+    width:50%;
+    float:left;
+}
 
 /*******************************************************************************
 Small Device Styles
@@ -430,6 +433,12 @@ Small Device Styles
     min-width: 320px;
     max-width: 480px;
     font-size: 11px;
+  }
+
+  .col {
+    margin:15px 0 0;
+    float:none;
+    width:100%;
   }
 
 }


### PR DESCRIPTION
I'm not sure what the history of this project is, but fundamentally it's
exporting JSON, and there's no typeface.js popular library as far as I
can tell. It seems like there's some overlap with Three.js but I don't
know what the overlap is.

This adds a checkbox to export JSON and strip the typeface JS header. See
https://github.com/mrdoob/three.js/issues/8262#issuecomment-191115072
for some more relevant details. Three.js currently expects the header
text to never change and be exactly 65 characters in length. This is
also problematic because fundamentally this is just a JSON file, and no
typeface library is loaded. A more robust solution is to just export raw
JSON, and then downstream Three.js can consume the JSON as is.
