### PR TITLE
Fix: missing glyphs with multiple unicodes

### DIFF
--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -74,11 +74,23 @@ var convert = function(font){
 	}
 	
     font.glyphs.forEach(function(glyph){
+        const unicodes = [];
         if (glyph.unicode !== undefined) {
-			var glyphCharacter = String.fromCharCode (glyph.unicode);
+            unicodes.push(glyph.unicode);
+        }
+        if (glyph.unicodes.length) {
+            glyph.unicodes.forEach(function(unicode){
+                if (unicodes.indexOf (unicode) == -1) {
+                    unicodes.push(unicode);
+                }
+            })
+        }
+       
+        unicodes.forEach(function(unicode){
+			var glyphCharacter = String.fromCharCode (unicode);
 			var needToExport = true;
 			if (restriction.range !== null) {
-				needToExport = (glyph.unicode >= restriction.range[0] && glyph.unicode <= restriction.range[1]);
+				needToExport = (unicode >= restriction.range[0] && unicode <= restriction.range[1]);
 			} else if (restriction.set !== null) {
 				needToExport = (restrictCharacterSetInput.value.indexOf (glyphCharacter) != -1);
 			}
@@ -113,9 +125,9 @@ var convert = function(font){
 						token.o += " "
 					}
 				});
-				result.glyphs[String.fromCharCode(glyph.unicode)] = token;
+				result.glyphs[String.fromCharCode(unicode)] = token;
 			}
-        };
+        });
     });
     result.familyName = font.familyName;
     result.ascender = Math.round(font.ascender * scale);


### PR DESCRIPTION
## Description
For glyphs with multiple unicodes, some of them wouldn't be included in the generated json file, which leads to the characters missing issue when the json is loaded in Three.js.
This pull request is created for fixing it in a **non-breaking** way.

## Motivation and Context
Among non-latin characters, some of them are bound to multiple unicodes, but when the character is decoded in javascript runtime, only one of the unicode would be decoded.
Here's a screenshot for better explanation.
<img width="640" alt="Screenshot 2023-07-14 at 12 40 33" src="https://github.com/gero3/facetype.js/assets/15889112/3ddb60f6-de3f-43ad-b812-71bb54b0ce47">
Here's a related unresolved issue. https://github.com/gero3/facetype.js/issues/25
Here's an open PR attempting to solve the same issue. https://github.com/gero3/facetype.js/pull/22

## How Has This Been Tested?
Here's the link of the fixed version. https://shuaibird.github.io/facetype.js/
A font file with the character `心` is uploaded in both the original version (A) & the forked version (B).
- Download both the generated json file without restrict set, load the files to render the character `心` in Three.js, only the json downloaded from B succeeds.
- Download both the generated json file with restrict set to `心`, check the generated files, only the json downloaded from B contains the `心` glyph.

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.